### PR TITLE
Fix issue with Grunt files handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ grunt.initConfig({
 
 ### Options
 
+This task uses the [standard Grunt file settings](http://gruntjs.com/configuring-tasks#files).
+
 #### src
 Type: `string`
 

--- a/tasks/task.js
+++ b/tasks/task.js
@@ -15,27 +15,32 @@ var Path = require('path')
 module.exports = function(grunt) {
 
   grunt.registerMultiTask('ttf2woff', Package.description, function() {
-    this.requiresConfig([this.name, this.target, 'src'].join('.'));
-    this.requiresConfig([this.name, this.target, 'dest'].join('.'));
-
     var done = this.async();
 
     this.files.forEach(function (files) {
 
 
       files.src.forEach(function(srcFile) {
+        var srcExt = Path.extname(srcFile),
+            fontName,
+            destFile = files.dest;
 
-        var ext = Path.extname(srcFile)
-          , fontName = Path.basename(srcFile, ext)
-          , destFile = Path.join(files.dest, fontName) + '.woff';
-
-        if('.ttf' !== ext) {
+        if('.ttf' !== srcExt) {
           grunt.log.fail('The given file seems to not be a TTF font ('
             + srcFile + ')');
         }
 
-        try {
+        // If we're not using grunt file expansion and dest is a directory, we'll
+        // need to build our dest path manually
+        if(!files.orig.expand && grunt.file.isDir(destFile)) {
+          fontName = fontName = Path.basename(srcFile, srcExt),
+          destFile = Path.join(files.dest, fontName) + '.woff';
+        } else {
+          // We didn't build the path, so make sure it has a .woff extension
+          destFile = destFile.replace(/.ttf$/, '.woff');
+        }
 
+        try {
           grunt.file.write(destFile,
             new Buffer(ttf2woff(
               new Uint8Array(grunt.file.read(srcFile, {


### PR DESCRIPTION
Fixes an issue with the handling of the 'expand' property, for example:

``` javascript
ttf2woff: {
  dist: {
    expand: true,
    cwd: 'src',
    src: 'fonts/*.ttf',
    dest: 'dist/'
  }
}
```

Given those settings, the source `src/fonts/some_font.ttf` the path produced was `dist/fonts/some_font.ttf/some_font.woff`, but now it is the correct path: `dist/fonts/some_font.woff`. Still compatible with the original usage.
